### PR TITLE
Mac delete order

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,5 +1,5 @@
-import { getSingleOrder } from './orderData';
-import getOrderItems from './orderItemsData';
+import { getSingleOrder, deleteOrder } from './orderData';
+import { getOrderItems, deleteOrderItem } from './orderItemsData';
 
 const getOrderDetails = async (firebaseKey) => {
   const order = await getSingleOrder(firebaseKey);
@@ -7,4 +7,14 @@ const getOrderDetails = async (firebaseKey) => {
   return { ...order, orderItems };
 };
 
-export default getOrderDetails;
+const deleteOrderRelationship = (firebaseKey) => new Promise((resolve, reject) => {
+  getOrderDetails(firebaseKey).then((orderArray) => {
+    const deleteOrderItemsFromOrder = orderArray.map((item) => deleteOrderItem(item.firebaseKey));
+
+    Promise.all(deleteOrderItemsFromOrder).then(() => {
+      deleteOrder(firebaseKey).then(resolve);
+    });
+  }).catch(reject);
+});
+
+export { getOrderDetails, deleteOrderRelationship };

--- a/api/orderData.js
+++ b/api/orderData.js
@@ -30,4 +30,15 @@ const getSingleOrder = (firebaseKey) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
-export { getOrders, getSingleOrder };
+const deleteOrder = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/orders/${firebaseKey}.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  }).then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export { getOrders, getSingleOrder, deleteOrder };

--- a/api/orderItemsData.js
+++ b/api/orderItemsData.js
@@ -18,4 +18,15 @@ const getOrderItems = (firebaseKey) => new Promise((resolve, reject) => {
     }).catch(reject);
 });
 
-export default getOrderItems;
+const deleteOrderItem = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/order_items/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  }).then((response) => response.json())
+    .then(resolve)
+    .catch(reject);
+});
+
+export { getOrderItems, deleteOrderItem };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
User is now able to delete an order and the corresponding order items. 

## Related Issue
Issue Tickets #23 #26 #30 

## Motivation and Context
This is a user requested feature. 

## How Can This Be Tested?
Delete function has been tested on local device with an up to date main branch. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
