### PR TITLE
Got edit order button event and edit order functionality working.

### DIFF
--- a/components/forms/createOrderForm.js
+++ b/components/forms/createOrderForm.js
@@ -25,7 +25,7 @@ const createOrderForm = (obj = {}) => {
     <option value="in-person">In-Person</option>
   </select>
   </div>
-  <button type="submit" class="btn btn-primary" id="submit-order-btn">Submit</button>
+  <button type="submit" class="btn btn-dark">${obj.firebaseKey ? 'Update' : 'Start Order'}</button>
   </form>
   `;
 

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,6 +1,6 @@
 import createOrderForm from '../components/forms/createOrderForm';
 import { getOrderDetails, deleteOrderRelationship } from '../api/mergedData';
-import { getOrders } from '../api/orderData';
+import { getOrders, getSingleOrder } from '../api/orderData';
 import { viewAllOrders, emptyOrders } from '../pages/orders';
 import viewOrderDetails from '../pages/viewOrderDetails';
 import addItemForm from '../components/forms/addItemForm';
@@ -55,7 +55,8 @@ const domEvents = (user) => {
 
   document.querySelector('#card-container').addEventListener('click', (e) => {
     if (e.target.id.includes('edit-details-btn')) {
-      createOrderForm();
+      const [, firebaseKey] = e.target.id.split('--');
+      getSingleOrder(firebaseKey).then((obj) => createOrderForm(obj));
     }
   });
 };

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -48,6 +48,12 @@ const domEvents = (user) => {
       createOrderForm();
     }
   });
+
+  document.querySelector('#card-container').addEventListener('click', (e) => {
+    if (e.target.id.includes('edit-details-btn')) {
+      createOrderForm();
+    }
+  });
 };
 
 export default domEvents;

--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -23,6 +23,21 @@ const formEvents = (user) => {
         });
       });
     }
+
+    if (e.target.id.includes('edit-order')) {
+      const [, firebaseKey] = e.target.id.split('--');
+      const payload = {
+        customerName: document.querySelector('#customerName').value,
+        phoneNumber: document.querySelector('#customerPhone').value,
+        email: document.querySelector('#customerEmail').value,
+        orderType: document.querySelector('#orderType').value,
+        uid: user.uid,
+        firebaseKey,
+      };
+      updateOrder(payload).then(() => {
+        getOrders(user.uid).then(viewAllOrders);
+      });
+    }
   });
 };
 

--- a/pages/orders.js
+++ b/pages/orders.js
@@ -17,7 +17,7 @@ const viewAllOrders = (array) => {
       domString += `<div class="card" id="order-card" style="width: 18rem;">
       <div class="card-body">
         <h5 class="card-title">${obj.customerName}</h5>
-        <ul>${obj.orderStatus}</ul>
+        <ul>Order Closed: ${obj.orderStatus}</ul>
         <ul>${obj.phoneNumber}</ul>
         <ul>${obj.email}</ul>
         <ul>${obj.orderType}</ul>

--- a/pages/viewOrderDetails.js
+++ b/pages/viewOrderDetails.js
@@ -18,7 +18,6 @@ const viewOrderDetails = (obj) => {
       <div class="card-body">
         <h5 class="card-title">${item.item_name}</h5>
           <p class="card-text bold">${item.item_price}</p>
-          <i id="edit-item-btn--${item.firebaseKey}" class="fas fa-edit btn btn-info"></i>
           <i id="delete-item-btn--${item.firebaseKey}" class="btn btn-danger fas fa-trash-alt"></i>
       </div>
     </div>`;

--- a/utils/sample_data/orders.json
+++ b/utils/sample_data/orders.json
@@ -4,7 +4,7 @@
     "customerId": "110.122.184.202/1",
     "phoneNumber": "971-603-8031",
     "email": "rgainforth0@123-reg.co.uk",
-    "orderType": true,
+    "orderType": "In-Person",
     "orderStatus": true,
     "firebaseKey": "280019251-8",
     "uid": "Uu9HWe2oDJbNGa7m8Bquf0aAyPk1"
@@ -14,7 +14,7 @@
     "customerId": "166.246.121.132/13",
     "phoneNumber": "298-901-3692",
     "email": "mfyldes1@ebay.com",
-    "orderType": false,
+    "orderType": "In-Person",
     "orderStatus": false,
     "firebaseKey": "010207055-5",
     "uid": "Uu9HWe2oDJbNGa7m8Bquf0aAyPk1"
@@ -24,7 +24,7 @@
     "customerId": "26.236.84.117/1",
     "phoneNumber": "228-274-0193",
     "email": "btewkesberry2@hc360.com",
-    "orderType": true,
+    "orderType": "Phone",
     "orderStatus": true,
     "firebaseKey": "594132184-8",
     "uid": "Uu9HWe2oDJbNGa7m8Bquf0aAyPk1"
@@ -34,7 +34,7 @@
     "customerId": "197.10.60.94/23",
     "phoneNumber": "848-154-6068",
     "email": "sfranke3@chicagotribune.com",
-    "orderType": false,
+    "orderType": "Phone",
     "orderStatus": false,
     "firebaseKey": "969618379-8",
     "uid": "Uu9HWe2oDJbNGa7m8Bquf0aAyPk1"
@@ -44,7 +44,7 @@
     "customerId": "132.83.88.19/12",
     "phoneNumber": "442-847-4446",
     "email": "edidsbury4@liveinternet.ru",
-    "orderType": false,
+    "orderType": "In-Person",
     "orderStatus": true,
     "firebaseKey": "194331063-7",
     "uid": "w7gGHCsxZegVnNnuVJzfGHNBPa43"
@@ -54,7 +54,7 @@
     "customerId": "95.86.9.170/11",
     "phoneNumber": "780-645-4309",
     "email": "hholleworth5@lulu.com",
-    "orderType": true,
+    "orderType": "Phone",
     "orderStatus": false,
     "firebaseKey": "233748873-X",
     "uid": "w7gGHCsxZegVnNnuVJzfGHNBPa43"
@@ -64,7 +64,7 @@
     "customerId": "75.50.141.45/4",
     "phoneNumber": "327-819-0102",
     "email": "ispeight6@xrea.com",
-    "orderType": false,
+    "orderType": "Phone",
     "orderStatus": true,
     "firebaseKey": "745189118-6",
     "uid": "w7gGHCsxZegVnNnuVJzfGHNBPa43"
@@ -74,7 +74,7 @@
     "customerId": "190.240.217.107/30",
     "phoneNumber": "477-246-5332",
     "email": "ncopland7@intel.com",
-    "orderType": true,
+    "orderType": "In-Person",
     "orderStatus": true,
     "firebaseKey": "407994654-6",
     "uid": "Q18AhEz1Y5PduR2XlNobmdUSpRE3"
@@ -84,7 +84,7 @@
     "customerId": "166.225.51.195/29",
     "phoneNumber": "256-625-7044",
     "email": "tbaurerich8@reference.com",
-    "orderType": true,
+    "orderType": "Phone",
     "orderStatus": false,
     "firebaseKey": "392165108-5",
     "uid": "Q18AhEz1Y5PduR2XlNobmdUSpRE3"
@@ -94,7 +94,7 @@
     "customerId": "148.213.195.26/11",
     "phoneNumber": "770-337-9643",
     "email": "wtrevett9@sitemeter.com",
-    "orderType": false,
+    "orderType": "Phone",
     "orderStatus": true,
     "firebaseKey": "973960909-0",
     "uid": "Q18AhEz1Y5PduR2XlNobmdUSpRE3"


### PR DESCRIPTION
## Description
Got edit-order-btn event listener working to render edit order form, upon hitting update button the order is edited instead of a new object being created. Also realized an edit order items button was unnecessary, as the ability to delete an order item and then add a new one in it's place is already available on the page and is more intuitive.

## Related Issue
#33 #36 

## Motivation and Context
This change

## How Can This Be Tested?
Edit orders can be tested by hitting the edit button within the order card on the view orders page, then editing the info in the provided form and hitting update button. When order page reloads the edited order should show new info.
For order items, functionality can be tested by hitting delete button within order item card then add item button at the bottom of the single order detail page and adding a new item.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
