### PR TITLE
Made event listener on go to payment button that renders payment order form

### DIFF
--- a/components/forms/paymentForm.js
+++ b/components/forms/paymentForm.js
@@ -1,0 +1,27 @@
+import clearDom from '../../utils/clearDom';
+import renderToDom from '../../utils/renderToDom';
+
+const paymentForm = (orderId) => {
+  clearDom();
+
+  let domString = '';
+  domString += `
+  <form id='payment-form--${orderId}'>
+    <select class="form-select" id="payment-close-order" aria-label="Payment Type" required>
+      <option selected>Select A Payment Type</option>
+      <option value="cash">Cash</option>
+      <option value="credit">Credit</option>
+      <option value="mobile">Mobile</option>
+    </select>
+    <div class="mb-3">
+      <label for="close-order-tip-input" class="form-label">Tip Amount</label>
+      <input type="number" name="currency" class="form-control" id="close-order-tip-input" aria-describedby="emailHelp" required>
+    </div>
+    <button type="submit" class="btn btn-primary" id="close-order-form--${orderId}">Close Order</button>
+  </form>
+  `;
+
+  renderToDom('#view-container', domString);
+};
+
+export default paymentForm;

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -4,6 +4,7 @@ import { getOrders, getSingleOrder } from '../api/orderData';
 import { viewAllOrders, emptyOrders } from '../pages/orders';
 import viewOrderDetails from '../pages/viewOrderDetails';
 import addItemForm from '../components/forms/addItemForm';
+import paymentForm from '../components/forms/paymentForm';
 
 /* eslint-disable no-alert */
 const domEvents = (user) => {
@@ -57,6 +58,12 @@ const domEvents = (user) => {
     if (e.target.id.includes('edit-details-btn')) {
       const [, firebaseKey] = e.target.id.split('--');
       getSingleOrder(firebaseKey).then((obj) => createOrderForm(obj));
+    }
+  });
+
+  document.querySelector('#view-container').addEventListener('click', (e) => {
+    if (e.target.id.includes('go-to-payment-btn')) {
+      paymentForm();
     }
   });
 };


### PR DESCRIPTION
## Description
Set event listener on go to payment button on order details page. Event listener opens a payment order form.

## Related Issue
#37 

## Motivation and Context
The payment order form will be required to select payment type and add tip, then close the order and add the revenue and tips from this order to the revenue page.

## How Can This Be Tested?
Can be tested by going to order details page and clicking go to payments button, which will bring up this order form.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
