### PR TITLE
user can view items in closed order

### DIFF
--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -8,7 +8,7 @@ import viewRevenue from '../pages/viewRevenue';
 import { getRevenue } from '../api/revenueData';
 import { deleteOrderItem, getSingleItem } from '../api/orderItemsData';
 import paymentForm from '../components/forms/paymentForm';
-import viewClosedOrders from '../pages/viewClosed';
+import { viewClosedOrders, viewClosedDetails } from '../pages/viewClosed';
 
 /* eslint-disable no-alert */
 const domEvents = (user) => {
@@ -73,11 +73,19 @@ const domEvents = (user) => {
     }
 
     if (e.target.id.includes('go-to-payment-btn')) {
-      paymentForm();
+      const [, firebaseKey] = e.target.id.split('--');
+      getOrderDetails(firebaseKey).then((obj) => paymentForm(obj));
     }
 
     if (e.target.id.includes('view-closed-orders')) {
       getOrders(user.uid).then((array) => viewClosedOrders(array));
+    }
+
+    if (e.target.id.includes('view-closed-details')) {
+      const [, firebaseKey] = e.target.id.split('--');
+      getOrderDetails(firebaseKey).then((data) => {
+        viewClosedDetails(data);
+      });
     }
   });
 };

--- a/pages/viewClosed.js
+++ b/pages/viewClosed.js
@@ -16,6 +16,7 @@ const viewClosedOrders = (array) => {
         <ul>${obj.phoneNumber}</ul>
         <ul>${obj.email}</ul>
         <ul>${obj.orderType}</ul>
+        <button type="button" id="view-closed-details--${obj.firebaseKey}" class="btn btn-outline-dark">View</button>
       </div>
     </div>
       `;
@@ -24,4 +25,21 @@ const viewClosedOrders = (array) => {
   renderToDom('#card-container', domString);
 };
 
-export default viewClosedOrders;
+const viewClosedDetails = (obj) => {
+  clearDom();
+  let domString = '';
+
+  obj.orderItems.forEach((item) => {
+    domString += `
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">${item.item_name}</h5>
+        <p class="card-text bold">${item.item_price.toFixed(2)}</p>
+    </div>
+  </div>`;
+  });
+
+  renderToDom('#view-container', domString);
+};
+
+export { viewClosedOrders, viewClosedDetails };


### PR DESCRIPTION
## Description
Added view button to closed order card, so you can see what items were in the order. Removed total because it would not reflect the amount paid in tip; that could be added in a later functionality (total paid).

## Related Issue
#76 

## Motivation and Context
This enables us to view more information about closed orders, so they don't "disappear."

## How Can This Be Tested?
click view all orders, click view closed orders, click view on card

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
